### PR TITLE
Fix provisiong example after commit eacdc1

### DIFF
--- a/example/lib/wifi_screen/wifi_bloc.dart
+++ b/example/lib/wifi_screen/wifi_bloc.dart
@@ -35,7 +35,16 @@ class WifiBloc extends Bloc<WifiEvent, WifiState> {
 
     try {
       var listWifi = await prov.startScanWiFi();
-      yield WifiStateLoaded(wifiList: listWifi ?? []);
+      List<Map<String, dynamic>> mapListWifi = [];
+      listWifi.forEach((element) {
+        mapListWifi.add({
+          'ssid': element.ssid,
+          'rssi': element.rssi,
+          'auth': element.private.toString() != 'Open'
+        });
+      });
+
+      yield WifiStateLoaded(mapListWifi);
       log.v('Wifi $listWifi');
     } catch (e) {
       log.e('Error scan WiFi network $e');


### PR DESCRIPTION
After commit eacdc1, Wifi scan response were converted from Map to Objects, but provisioning example is still expecting a Map. A backward conversion from Objects to Map has been introduce to keep it compatible.